### PR TITLE
Simplified methods/guest/Cargo.toml

### DIFF
--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [build-dependencies]
 risc0-build = "0.7"
 
-[target.riscv32im-unknown-none-elf.dependencies]
+[dependencies]
 risc0-zkvm-guest = "0.7"


### PR DESCRIPTION
# A minor change to `methods/guest/Cargo.toml`

The `risc0-build` procedure does not require `[target.riscv32im-unknown-none-elf.dependencies]` in `Cargo.toml`.

Simply using `[dependencies]` seems to work.