### PR TITLE
Clarify comment

### DIFF
--- a/starter/src/main.rs
+++ b/starter/src/main.rs
@@ -10,10 +10,10 @@ fn main() {
     // Multiply them inside the ZKP
     // First, we make the prover, loading the 'multiply' method
     let mut prover = Prover::new(&std::fs::read(MULTIPLY_PATH).unwrap(), MULTIPLY_ID).unwrap();
-    // Next we send a + b to the guest
+    // Next we send a & b to the guest
     prover.add_input(to_vec(&a).unwrap().as_slice()).unwrap();
     prover.add_input(to_vec(&b).unwrap().as_slice()).unwrap();
-    // Run prover + generate receipt
+    // Run prover & generate receipt
     let receipt = prover.run().unwrap();
 
     // Extract journal of receipt (i.e. output c, where c = a * b)


### PR DESCRIPTION
Minor tweak: Change `+` to `&` in the comment to clarify that two values are being provided, not a sum of values (since I somehow managed to briefly confuse myself into thinking that the sum a + b was being provided to the guest, leading me to wonder about the cryptographic purpose of providing this sum).