### PR TITLE
Remove explicit target of Wasm in toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,4 @@
 [toolchain]
 channel = "nightly-2022-06-20"
 components = [ "rustfmt", "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
@rlukata do you see any reason this repo shouldn't follow the same approach as you used in https://github.com/risc0/risc0-rust-examples/pull/14?