### PR TITLE
Depend on RISC Zero HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Search this template for the string `TODO`, and make the necessary changes to im
  * Reference documentation for our Rust crates is available at [docs.rs], including the [RISC Zero zkVM crate](https://docs.rs/risc0-zkvm), the [RISC Zero zkVM guest crate](https://docs.rs/risc0-zkvm-guest), the [RISC Zero build crate](https://docs.rs/risc0-build), and others (the full list is available at [https://github.com/risc0/risc0/blob/main/README.md]).
  * Our [main repository](https://www.github.com/risc0/risc0).
 
+## Stable Versions
+By default, this template depends on the latest version of RISC Zero: the `main` branch of our [main repository](http://www.github.com/risc0). This gives you access to our latest features and improvements. If you would prefer to use our more stable published crates, we have tags matching those crates that you can use, e.g. `v0.11.1`.
+
 ## Contributor's Guide
 We welcome contributions to documentation and code via PRs and GitHub Issues on our [main repository](http://www.github.com/risc0), this repository, or any of our other repositories.
 

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = "0.11"
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git" }
 serde = "1.0"

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,6 +1,6 @@
 // TODO: Update the name of the method loaded by the prover. E.g., if the method is `multiply`, replace `METHOD_NAME_ID` with `MULTIPLY_ID` and replace `METHOD_NAME_PATH` with `MULTIPLY_PATH`
 use methods::{METHOD_NAME_ID, METHOD_NAME_PATH};
-use risc0_zkvm::host::Prover;
+use risc0_zkvm::Prover;
 // use risc0_zkvm::serde::{from_slice, to_vec};
 
 fn main() {

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "0.11"
+risc0-build = { git = "https://github.com/risc0/risc0.git" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [build-dependencies]
-risc0-build = "0.11"
+risc0-build = { git = "https://github.com/risc0/risc0.git" }
 
 [dependencies]
-risc0-zkvm-guest = "0.11"
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", default-features = false }

--- a/methods/guest/build.rs
+++ b/methods/guest/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    risc0_build::link();
-}

--- a/methods/guest/src/bin/method_name.rs
+++ b/methods/guest/src/bin/method_name.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]  // std support is experimental, but you can remove this to try it
 
-risc0_zkvm_guest::entry!(main);
+risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     // TODO: Implement your guest code here

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-20"
+channel = "nightly-2022-08-16"
 components = [ "rustfmt", "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
This changes the `main` branch of this repository to depend on the `main` branch of our main repository (at https://github.com/risc0/risc0).

It also adds a section to the README telling users that they can find tags if they want to depend on versioned crates instead.

This addresses the discussion in #24