### PR TITLE
Pin risc0 dependency commit

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
 serde = "1.0"

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0.git" }
+risc0-build = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0.git" }
+risc0-build = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
 
 [dependencies]
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", default-features = false }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b", default-features = false }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-08-16"
+channel = "nightly-2022-10-28"
 components = [ "rustfmt", "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
Per the discussion in https://github.com/risc0/risc0-rust-starter/pull/26, this pins the starter repo to a specific commit of the https://github.com/risc0/risc0 repo