### PR TITLE
Update to risc0 v0.12

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
+risc0-zkvm = "0.12"
 serde = "1.0"

--- a/methods/Cargo.toml
+++ b/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
+risc0-build = "0.12"
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b" }
+risc0-build = "0.12"
 
 [dependencies]
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "52c48e0da6294b94151a31120b8f70b1b8d3576b", default-features = false }
+risc0-zkvm = { version = "0.12", default-features = false }


### PR DESCRIPTION
Update the starter template to 0.12. We had already moved to fairly recent commit in #27, so this is a simple change.