### PR TITLE
Use upgraded 0.12 features

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 
     // Run prover & generate receipt
     let receipt = prover.run()
-        .expect("Code should be provable unless it 1) had an error or 2) overflowed the cycle limit. See `embed_methods_with_options` for information on adjusting maximum cycle count.");
+        .expect("Code should be provable unless it had an error or overflowed the maximum cycle count");
 
     // Optional: Verify receipt to confirm that recipients will also be able to verify your receipt
     receipt.verify(METHOD_NAME_ID).expect(

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,13 +1,11 @@
-// TODO: Update the name of the method loaded by the prover. E.g., if the method is `multiply`, replace `METHOD_NAME_ID` with `MULTIPLY_ID` and replace `METHOD_NAME_PATH` with `MULTIPLY_PATH`
-use methods::{METHOD_NAME_ID, METHOD_NAME_PATH};
+// TODO: Update the name of the method loaded by the prover. E.g., if the method is `multiply`, replace `METHOD_NAME_ELF` with `MULTIPLY_ELF` and replace `METHOD_NAME_ID` with `MULTIPLY_ID`
+use methods::{METHOD_NAME_ELF, METHOD_NAME_ID};
 use risc0_zkvm::Prover;
 // use risc0_zkvm::serde::{from_slice, to_vec};
 
 fn main() {
     // Make the prover.
-    let method_code = std::fs::read(METHOD_NAME_PATH)
-        .expect("Method code should be present at the specified path; did you use the correct *_PATH constant?");
-    let mut prover = Prover::new(&method_code, METHOD_NAME_ID).expect(
+    let mut prover = Prover::new(METHOD_NAME_ELF, METHOD_NAME_ID).expect(
         "Prover should be constructed from valid method source code and corresponding method ID",
     );
 

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 risc0-build = "0.12"
 
 [dependencies]
+# If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
 risc0-zkvm = { version = "0.12", default-features = false }

--- a/methods/guest/src/bin/method_name.rs
+++ b/methods/guest/src/bin/method_name.rs
@@ -1,7 +1,8 @@
 // TODO: Rename this file to change the name of this method from METHOD_NAME
 
 #![no_main]
-#![no_std]  // std support is experimental, but you can remove this to try it
+// If you want to try std support, also update the guest Cargo.toml file
+#![no_std]  // std support is experimental
 
 risc0_zkvm::guest::entry!(main);
 


### PR DESCRIPTION
With 0.12, we can now directly build the prover from the Elf contents rather than needing to load a file. So, replace `*_PATH` with `*_ELF` as directly using the Elf contents is now the recommended approach.

Also, we no longer need to mention upgrading the cycle count, as our new ImageID techniques let us automatically use the maximum cycle count.